### PR TITLE
Fix java.lang.IllegalArgumentException with Android Bubbles Notification

### DIFF
--- a/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
+++ b/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
@@ -525,16 +525,12 @@ public class BubbleNotificationsModule extends ReactContextBaseJavaModule {
     // at com.txusballesteros.bubbles.BubblesService$1.run (BubblesService.java:68)
     // Checks to make sure the current activity is attached to view before
     // trying to remove any views
-    Log.d("BubbleNotifications", "removeBubble() - currentActivity exists");
     if (bubbleView != null && ViewCompat.isAttachedToWindow(bubbleView)) {
       try {
-        Log.d("BubbleNotifications", "removeBubble() - bubbleView exists");
         bubblesManager.removeBubble(bubbleView);
         bubbleStatus.put("ShowingBubble", new Boolean(false));
       } catch (Exception e) {
       }
-    } else {
-      Log.d("BubbleNotifications", "removeBubble() - bubbleView not attached to window");
     }
   }
 

--- a/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
+++ b/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
@@ -517,6 +517,11 @@ public class BubbleNotificationsModule extends ReactContextBaseJavaModule {
   }
 
   private void removeBubble() {
+    Activity currentActivity = getCurrentActivity();
+    if (currentActivity.this.isDestroyed()) {
+      return;
+    }
+
     if (bubbleView != null) {
       try {
         bubblesManager.removeBubble(bubbleView);

--- a/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
+++ b/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
@@ -525,9 +525,11 @@ public class BubbleNotificationsModule extends ReactContextBaseJavaModule {
     // doing any work on it
     Activity currentActivity = getCurrentActivity();
     if (currentActivity == null) {
+      Log.d("BubbleNotifications", "removeBubble() - currentActivity == null");
       return;
     }
 
+    Log.d("BubbleNotifications", "removeBubble() - currentActivity exists");
     if (bubbleView != null) {
       try {
         bubblesManager.removeBubble(bubbleView);

--- a/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
+++ b/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
@@ -517,8 +517,14 @@ public class BubbleNotificationsModule extends ReactContextBaseJavaModule {
   }
 
   private void removeBubble() {
+    // Fixes error thrown in production in Wridz v2.3.21 and below
+    // Exception java.lang.IllegalArgumentException:
+    // at android.view.WindowManagerImpl.removeView (WindowManagerImpl.java:201)
+    // at com.txusballesteros.bubbles.BubblesService$1.run (BubblesService.java:68)
+    // Checks to make sure the current activity is not destroyed before
+    // doing any work on it
     Activity currentActivity = getCurrentActivity();
-    if (currentActivity.this.isDestroyed()) {
+    if (currentActivity == null) {
       return;
     }
 

--- a/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
+++ b/android/src/main/java/com/reactnativebubblenotifications/BubbleNotificationsModule.java
@@ -3,6 +3,7 @@ package com.reactnativebubblenotifications;
 import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.ViewCompat;
 
 import android.text.Layout;
 import android.util.Log;
@@ -517,25 +518,23 @@ public class BubbleNotificationsModule extends ReactContextBaseJavaModule {
   }
 
   private void removeBubble() {
-    // Fixes error thrown in production in Wridz v2.3.21 and below
+    // Bug fix for Wridz app v2.3.21 and below
+    // NEW LINE: ViewCompat.isAttachedToWindow(bubbleView)
     // Exception java.lang.IllegalArgumentException:
     // at android.view.WindowManagerImpl.removeView (WindowManagerImpl.java:201)
     // at com.txusballesteros.bubbles.BubblesService$1.run (BubblesService.java:68)
-    // Checks to make sure the current activity is not destroyed before
-    // doing any work on it
-    Activity currentActivity = getCurrentActivity();
-    if (currentActivity == null) {
-      Log.d("BubbleNotifications", "removeBubble() - currentActivity == null");
-      return;
-    }
-
+    // Checks to make sure the current activity is attached to view before
+    // trying to remove any views
     Log.d("BubbleNotifications", "removeBubble() - currentActivity exists");
-    if (bubbleView != null) {
+    if (bubbleView != null && ViewCompat.isAttachedToWindow(bubbleView)) {
       try {
+        Log.d("BubbleNotifications", "removeBubble() - bubbleView exists");
         bubblesManager.removeBubble(bubbleView);
         bubbleStatus.put("ShowingBubble", new Boolean(false));
       } catch (Exception e) {
       }
+    } else {
+      Log.d("BubbleNotifications", "removeBubble() - bubbleView not attached to window");
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue causing crashes with the BubblesLayout Activity on android devices. See Exception:

```
java.lang.IllegalArgumentException: View=com.txusballesteros.bubbles.BubbleLayout{6dd27dd VFE...C.. ........ 0,0-210,225} not attached to window manager

FATAL EXCEPTION: main
Process: com.wridz.app, PID: 18047
java.lang.IllegalArgumentException: View=com.txusballesteros.bubbles.BubbleLayout{6dd27dd VFE...C.. ........ 0,0-210,225} not attached to window manager
	at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:733)
	at android.view.WindowManagerGlobal.removeView(WindowManagerGlobal.java:619)
	at android.view.WindowManagerImpl.removeView(WindowManagerImpl.java:201)
	at com.txusballesteros.bubbles.BubblesService$1.run(BubblesService.java:68)
	at android.os.Handler.handleCallback(Handler.java:942)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at android.app.ActivityThread.main(ActivityThread.java:8762)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

Added a check on the view to ensure it is attached to the window manager prior to attempting to remove it. If the view is not attached, then the logic to remove the view is skipped.
	